### PR TITLE
remove method broken

### DIFF
--- a/lib/weedfs.js
+++ b/lib/weedfs.js
@@ -301,7 +301,7 @@ WeedFSClient.prototype = {
                 var proms = [];
                 for (var i = 0, len = result.locations.length; i < len; i++) {
                     proms.push(new Promise(function (resolve, reject) {
-                        var req = http.request(url.parse("http://" + (self.usePublicUrl? result.locations[i].publicUrl : result.locations[i].url) + "/" + fid), function (res) {
+                        var req = http.request(Object.assign(url.parse("http://" + (self.usePublicUrl? result.locations[i].publicUrl : result.locations[i].url) + "/" + fid), {"method": "DELETE"}), function (res) {
                             if (res.statusCode === 404) {
                                 var err = new SeaweedFSError("file '" + fid + "' not found");
                                 return reject(err);


### PR DESCRIPTION
# WHY / WHAT

The rest api look like

```
curl -X DELETE http://127.0.0.1:8080/3,01637037d6
```

and source code only use default htttp method "GET", so this method broken.
# REFERENCE

https://github.com/chrislusf/seaweedfs/wiki/API#delete-file
